### PR TITLE
Fix/Manifest view refreshes after rotating device

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -45,8 +45,7 @@
             android:label="@string/history_activity" />
 
         <activity
-            android:name=".manifest.ManifestViewerActivity"
-            android:configChanges="orientation|screenSize" />
+            android:name=".manifest.ManifestViewerActivity" />
 
         <activity android:name=".app.ActivitiesListActivity" />
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -44,8 +44,7 @@
             android:exported="true"
             android:label="@string/history_activity" />
 
-        <activity
-            android:name=".manifest.ManifestViewerActivity" />
+        <activity android:name=".manifest.ManifestViewerActivity" />
 
         <activity android:name=".app.ActivitiesListActivity" />
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -44,7 +44,9 @@
             android:exported="true"
             android:label="@string/history_activity" />
 
-        <activity android:name=".manifest.ManifestViewerActivity" />
+        <activity
+            android:name=".manifest.ManifestViewerActivity"
+            android:configChanges="orientation|screenSize" />
 
         <activity android:name=".app.ActivitiesListActivity" />
 

--- a/app/src/main/java/com/sdex/activityrunner/manifest/ManifestViewModel.kt
+++ b/app/src/main/java/com/sdex/activityrunner/manifest/ManifestViewModel.kt
@@ -11,8 +11,8 @@ import kotlinx.coroutines.launch
 
 class ManifestViewModel(application: Application) : AndroidViewModel(application) {
 
-    private val _manifestLiveData = MutableLiveData<ManifestState>()
-    val manifestLiveData: LiveData<ManifestState> = _manifestLiveData
+    private val _manifestLiveData = MutableLiveData<String?>()
+    val manifestLiveData: LiveData<String?> = _manifestLiveData
 
     private var job: Job? = null
 
@@ -24,20 +24,10 @@ class ManifestViewModel(application: Application) : AndroidViewModel(application
             val manifestReader = ManifestReader()
             val manifestWriter = ManifestWriter()
             val manifest = manifestReader.loadAndroidManifest(getApplication(), packageName)
-            _manifestLiveData.postValue(ManifestState(false,manifest ?: "Error during parsing AndroidManifest.xml"))
+            _manifestLiveData.postValue(manifest)
             manifestWriter.saveAndroidManifest(getApplication(), packageName, manifest)
         }
     }
-
-    fun updatePosition(position: Int) {
-        _manifestLiveData.value = _manifestLiveData.value?.copy(position = position, isDataReady = false)
-    }
-
-    fun setDataReady() {
-        _manifestLiveData.value = _manifestLiveData.value?.copy(isDataReady = true)
-    }
-
-    data class ManifestState(val isDataReady: Boolean, val data: String, val position: Int = 0)
 
     override fun onCleared() {
         super.onCleared()

--- a/app/src/main/java/com/sdex/activityrunner/manifest/ManifestViewModel.kt
+++ b/app/src/main/java/com/sdex/activityrunner/manifest/ManifestViewModel.kt
@@ -18,11 +18,13 @@ class ManifestViewModel(application: Application) : AndroidViewModel(application
 
     fun loadManifest(packageName: String) {
         job?.cancel()
+        // parsing is one time operation, so check for filled live data to avoid unnecessary recreating
+        if(_manifestLiveData.value != null) return
         job = viewModelScope.launch(Dispatchers.IO) {
             val manifestReader = ManifestReader()
             val manifestWriter = ManifestWriter()
             val manifest = manifestReader.loadAndroidManifest(getApplication(), packageName)
-            _manifestLiveData.postValue(manifest)
+            _manifestLiveData.postValue(manifest ?: "Error during parsing AndroidManifest.xml")
             manifestWriter.saveAndroidManifest(getApplication(), packageName, manifest)
         }
     }

--- a/app/src/main/java/com/sdex/activityrunner/manifest/ManifestViewModel.kt
+++ b/app/src/main/java/com/sdex/activityrunner/manifest/ManifestViewModel.kt
@@ -18,8 +18,9 @@ class ManifestViewModel(application: Application) : AndroidViewModel(application
 
     fun loadManifest(packageName: String) {
         job?.cancel()
-        // parsing is one time operation, so check for filled live data to avoid unnecessary recreating
-        if(_manifestLiveData.value != null) return
+        if (_manifestLiveData.value != null) {
+            return
+        }
         job = viewModelScope.launch(Dispatchers.IO) {
             val manifestReader = ManifestReader()
             val manifestWriter = ManifestWriter()

--- a/app/src/main/java/com/sdex/activityrunner/manifest/ManifestViewModel.kt
+++ b/app/src/main/java/com/sdex/activityrunner/manifest/ManifestViewModel.kt
@@ -11,8 +11,8 @@ import kotlinx.coroutines.launch
 
 class ManifestViewModel(application: Application) : AndroidViewModel(application) {
 
-    private val _manifestLiveData = MutableLiveData<String>()
-    val manifestLiveData: LiveData<String> = _manifestLiveData
+    private val _manifestLiveData = MutableLiveData<ManifestState>()
+    val manifestLiveData: LiveData<ManifestState> = _manifestLiveData
 
     private var job: Job? = null
 
@@ -24,10 +24,20 @@ class ManifestViewModel(application: Application) : AndroidViewModel(application
             val manifestReader = ManifestReader()
             val manifestWriter = ManifestWriter()
             val manifest = manifestReader.loadAndroidManifest(getApplication(), packageName)
-            _manifestLiveData.postValue(manifest ?: "Error during parsing AndroidManifest.xml")
+            _manifestLiveData.postValue(ManifestState(false,manifest ?: "Error during parsing AndroidManifest.xml"))
             manifestWriter.saveAndroidManifest(getApplication(), packageName, manifest)
         }
     }
+
+    fun updatePosition(position: Int) {
+        _manifestLiveData.value = _manifestLiveData.value?.copy(position = position, isDataReady = false)
+    }
+
+    fun setDataReady() {
+        _manifestLiveData.value = _manifestLiveData.value?.copy(isDataReady = true)
+    }
+
+    data class ManifestState(val isDataReady: Boolean, val data: String, val position: Int = 0)
 
     override fun onCleared() {
         super.onCleared()

--- a/app/src/main/java/com/sdex/activityrunner/manifest/ManifestViewerActivity.kt
+++ b/app/src/main/java/com/sdex/activityrunner/manifest/ManifestViewerActivity.kt
@@ -171,7 +171,7 @@ class ManifestViewerActivity : BaseActivity() {
 
     override fun onDestroy() {
         super.onDestroy()
-        scrollCallback?.let { binding.progress.removeCallbacks(it) }
+        scrollCallback?.let { binding.highlightView.removeCallbacks(it) }
     }
 
     companion object {

--- a/app/src/main/java/com/sdex/activityrunner/manifest/ManifestViewerActivity.kt
+++ b/app/src/main/java/com/sdex/activityrunner/manifest/ManifestViewerActivity.kt
@@ -28,12 +28,10 @@ class ManifestViewerActivity : BaseActivity() {
     private val appPreferences by lazy { AppPreferences(this) }
     private lateinit var binding: ActivityManifestViewerBinding
     private lateinit var appPackageName: String
-    private var position = 0
 
     override fun onCreate(savedInstanceState: Bundle?) {
         try {
             super.onCreate(savedInstanceState)
-            position = savedInstanceState?.getInt(ARG_POSITION, 0) ?: 0
         } catch (e: Exception) {
             // probably android.webkit.WebViewFactory.MissingWebViewPackageException
             Toast.makeText(
@@ -61,7 +59,6 @@ class ManifestViewerActivity : BaseActivity() {
             setShowLineNumbers(true)
             setZoomSupportEnabled(true)
             setOnContentChangedListener {
-                scrollTo(0, position)
                 binding.progress.hide()
             }
         }
@@ -155,11 +152,6 @@ class ManifestViewerActivity : BaseActivity() {
                         (resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK ==
                                 Configuration.UI_MODE_NIGHT_YES))
 
-    override fun onSaveInstanceState(outState: Bundle) {
-        outState.putInt(ARG_POSITION, binding.highlightView.scrollPosition)
-        super.onSaveInstanceState(outState)
-    }
-
     override fun onDestroy() {
         super.onDestroy()
         binding.highlightView.setOnContentChangedListener(null)
@@ -169,7 +161,6 @@ class ManifestViewerActivity : BaseActivity() {
 
         private const val ARG_PACKAGE_NAME = "arg_package_name"
         private const val ARG_NAME = "arg_name"
-        private const val ARG_POSITION = "arg_position"
 
         fun start(context: Context, model: ApplicationModel) {
             context.startActivity(Intent(context, ManifestViewerActivity::class.java).apply {

--- a/app/src/main/java/com/sdex/highlightjs/HighlightJsView.java
+++ b/app/src/main/java/com/sdex/highlightjs/HighlightJsView.java
@@ -9,6 +9,7 @@ import android.util.Log;
 import android.view.View;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
+import android.webkit.WebViewClient;
 
 import androidx.annotation.NonNull;
 
@@ -34,6 +35,7 @@ public class HighlightJsView extends WebView implements FileUtils.Callback {
     private String content;
     private boolean zoomSupport = false;
     private boolean showLineNumbers = false;
+    private int scrollPosition = 0;
 
     //local variables to register callbacks
     private OnLanguageChangedListener onLanguageChangedListener;
@@ -82,6 +84,15 @@ public class HighlightJsView extends WebView implements FileUtils.Callback {
     private void initView(Context context) {
         //make sure the view is blank
         loadUrl("about:blank");
+        setWebViewClient(new WebViewClient(){
+            @Override
+            public void onPageFinished(WebView view, String url) {
+                super.onPageFinished(view, url);
+                if(url.equals("about:blank")) return;
+                //notify the callback (if set)
+                if (onContentChangedListener != null) onContentChangedListener.onContentChanged();
+            }
+        });
         //set the settings for the view
         WebSettings settings = getSettings();
         settings.setJavaScriptEnabled(true);
@@ -179,8 +190,6 @@ public class HighlightJsView extends WebView implements FileUtils.Callback {
             this.content = source;
             String page = SourceUtils.generateContent(source, theme.getName(), language.getName(), zoomSupport, showLineNumbers);
             loadDataWithBaseURL("file:///android_asset/", page, "text/html", "utf-8", null);
-            //notify the callback (if set)
-            if (onContentChangedListener != null) onContentChangedListener.onContentChanged();
         } else Log.e(getClass().getSimpleName(), "Source can't be null or empty.");
     }
 
@@ -236,5 +245,15 @@ public class HighlightJsView extends WebView implements FileUtils.Callback {
      */
     public void setShowLineNumbers(boolean showLineNumbers) {
         this.showLineNumbers = showLineNumbers;
+    }
+
+    public int getScrollPosition() {
+        return scrollPosition;
+    }
+
+    @Override
+    protected void onScrollChanged(int l, int t, int oldl, int oldt) {
+        super.onScrollChanged(l, t, oldl, oldt);
+        this.scrollPosition = t;
     }
 }

--- a/app/src/main/java/com/sdex/highlightjs/HighlightJsView.java
+++ b/app/src/main/java/com/sdex/highlightjs/HighlightJsView.java
@@ -10,14 +10,11 @@ import android.view.View;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
-
 import androidx.annotation.NonNull;
-
 import com.sdex.highlightjs.models.Language;
 import com.sdex.highlightjs.models.Theme;
 import com.sdex.highlightjs.utils.FileUtils;
 import com.sdex.highlightjs.utils.SourceUtils;
-
 import java.io.File;
 import java.net.URL;
 
@@ -83,12 +80,10 @@ public class HighlightJsView extends WebView implements FileUtils.Callback {
     @SuppressLint("SetJavaScriptEnabled")
     private void initView(Context context) {
         //make sure the view is blank
-        loadUrl("about:blank");
         setWebViewClient(new WebViewClient(){
             @Override
             public void onPageFinished(WebView view, String url) {
                 super.onPageFinished(view, url);
-                if(url.equals("about:blank")) return;
                 //notify the callback (if set)
                 if (onContentChangedListener != null) onContentChangedListener.onContentChanged();
             }
@@ -255,5 +250,10 @@ public class HighlightJsView extends WebView implements FileUtils.Callback {
     protected void onScrollChanged(int l, int t, int oldl, int oldt) {
         super.onScrollChanged(l, t, oldl, oldt);
         this.scrollPosition = t;
+    }
+
+    @Override
+    public void onViewRemoved(View child) {
+        super.onViewRemoved(child);
     }
 }

--- a/app/src/main/java/com/sdex/highlightjs/HighlightJsView.java
+++ b/app/src/main/java/com/sdex/highlightjs/HighlightJsView.java
@@ -251,9 +251,4 @@ public class HighlightJsView extends WebView implements FileUtils.Callback {
         super.onScrollChanged(l, t, oldl, oldt);
         this.scrollPosition = t;
     }
-
-    @Override
-    public void onViewRemoved(View child) {
-        super.onViewRemoved(child);
-    }
 }


### PR DESCRIPTION
* reworked live data
* added ability to restore scroll state on screen rotation
* added single shot loading data for manifest instead on recreating data each time on rotation

closes #3