### PR TITLE
* Fixed Issue #4: Notices scroll position also gets lost after device rotation

### DIFF
--- a/app/src/main/java/com/sdex/commons/license/LicensesDialogFragment.kt
+++ b/app/src/main/java/com/sdex/commons/license/LicensesDialogFragment.kt
@@ -8,14 +8,20 @@ import android.os.Bundle
 import android.os.Message
 import android.webkit.WebChromeClient
 import android.webkit.WebView
+import android.webkit.WebViewClient
 import androidx.appcompat.app.AlertDialog
 import com.sdex.activityrunner.R
 import com.sdex.commons.BaseDialogFragment
 
 class LicensesDialogFragment : BaseDialogFragment() {
 
+    private var scrollPosition = 0
+
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        val webView = createWebView(requireContext())
+        scrollPosition = savedInstanceState?.getInt(ARG_POSITION, 0) ?: 0
+        val webView = createWebView(requireContext(), scrollPosition) {
+            scrollPosition = it
+        }
         webView.loadUrl("file:///android_asset/licenses.html")
         return AlertDialog.Builder(requireContext())
             .setTitle(R.string.dialog_license_title)
@@ -24,8 +30,28 @@ class LicensesDialogFragment : BaseDialogFragment() {
             .create()
     }
 
-    private fun createWebView(context: Context): WebView {
-        val webView = WebView(context)
+    override fun onSaveInstanceState(outState: Bundle) {
+        outState.putInt(ARG_POSITION, scrollPosition)
+        super.onSaveInstanceState(outState)
+    }
+
+    private fun createWebView(
+        context: Context,
+        position: Int,
+        onPositionChanged: (Int) -> Unit
+    ): WebView {
+        val webView = object : WebView(context) {
+            override fun onScrollChanged(l: Int, t: Int, oldl: Int, oldt: Int) {
+                super.onScrollChanged(l, t, oldl, oldt)
+                onPositionChanged(t)
+            }
+        }
+        webView.webViewClient = object : WebViewClient() {
+            override fun onPageFinished(view: WebView?, url: String?) {
+                super.onPageFinished(view, url)
+                view?.scrollTo(0, position)
+            }
+        }
         webView.settings.setSupportMultipleWindows(true)
         webView.webChromeClient = object : WebChromeClient() {
             override fun onCreateWindow(
@@ -45,7 +71,7 @@ class LicensesDialogFragment : BaseDialogFragment() {
     }
 
     companion object {
-
         const val TAG = "LicensesDialogFragment"
+        private const val ARG_POSITION = "arg_position"
     }
 }


### PR DESCRIPTION
* Save position to bundle in save state and restore it after each rotation.
* Checked just for Y position, it will be enough in this case.