### PR TITLE
* Fixed Issue #5: Data loss while using the app (dialog disappears on-screen rotation)

### DIFF
--- a/app/src/main/java/com/sdex/activityrunner/preferences/SettingsActivity.kt
+++ b/app/src/main/java/com/sdex/activityrunner/preferences/SettingsActivity.kt
@@ -15,10 +15,11 @@ class SettingsActivity : BaseActivity() {
         binding = ActivitySettingsBinding.inflate(layoutInflater)
         setContentView(binding.root)
         setupToolbar(isBackButtonEnabled = true)
-
-        supportFragmentManager.beginTransaction()
-            .replace(binding.content.id, SettingsFragment())
-            .commitNow()
+        if (savedInstanceState == null) {
+            supportFragmentManager.beginTransaction()
+                .replace(binding.content.id, SettingsFragment())
+                .commitNow()
+        }
     }
 
     companion object {


### PR DESCRIPTION
Root case: rotation every time recreates the SettingsFragment(), so the dialog, that attached to previous(desctoyed) fragment, can be restored.

closes #5