### PR TITLE
solve issue of low contrast

### DIFF
--- a/app/src/main/res/layout/item_activity.xml
+++ b/app/src/main/res/layout/item_activity.xml
@@ -36,7 +36,7 @@
             android:id="@+id/packageName"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textColor="@color/text_color_secondary"
+            android:textColor="#757575"
             android:textSize="14sp"
             tools:text="com.app.package" />
 

--- a/app/src/main/res/layout/item_application.xml
+++ b/app/src/main/res/layout/item_application.xml
@@ -36,7 +36,7 @@
             android:id="@+id/packageName"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textColor="@color/text_color_secondary"
+            android:textColor="#757575"
             android:textSize="14sp"
             tools:text="com.android.application" />
 

--- a/app/src/main/res/layout/item_history.xml
+++ b/app/src/main/res/layout/item_history.xml
@@ -31,7 +31,7 @@
         android:layout_height="wrap_content"
         android:ellipsize="end"
         android:maxLines="1"
-        android:textColor="@color/text_color_primary"
+        android:textColor="#757575"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/c1"
         app:layout_constraintTop_toTopOf="parent"


### PR DESCRIPTION
The original text color of the component is '#FFFFFF', and the contrast between the text color ('#FFFFFF') and the background color ('#AAAAAA') does not meet the standard of WCAG 2.1. In other words, this color cannot be easily seen by everyone. So, to solve this problem, our team designed a tool that can automatically detect and repair such problems. The test report and recommended replacement colors ('#757575') are as follows:
![image](https://user-images.githubusercontent.com/101503193/211337802-0231f3f3-26b0-4636-b17f-4fb5faf90a8c.png)

The figure on the left is the original page, the figure on the right is the repaired page, and the figure below is the problem detection report.
If you think it is useful, please give me feedback. Your feedback is very important to me. We sincerely hope to receive your suggestions and opinions as an app developer.