### PR TITLE
feat: add activity label in shortcut dialog

### DIFF
--- a/app/src/main/java/com/sdex/activityrunner/shortcut/AddShortcutDialogActivity.kt
+++ b/app/src/main/java/com/sdex/activityrunner/shortcut/AddShortcutDialogActivity.kt
@@ -7,6 +7,8 @@ import android.graphics.Bitmap
 import android.graphics.drawable.Drawable
 import android.net.Uri
 import android.os.Bundle
+import android.text.Editable
+import android.text.TextWatcher
 import android.view.View
 import android.widget.PopupMenu
 import android.widget.Toast
@@ -17,6 +19,7 @@ import androidx.core.graphics.drawable.toBitmap
 import com.bumptech.glide.request.RequestOptions
 import com.bumptech.glide.request.target.CustomTarget
 import com.bumptech.glide.request.transition.Transition
+import com.google.android.material.textfield.TextInputLayout
 import com.maltaisn.icondialog.IconDialog
 import com.maltaisn.icondialog.IconDialogSettings
 import com.maltaisn.icondialog.data.Icon
@@ -60,8 +63,23 @@ class AddShortcutDialogActivity : AppCompatActivity(), IconDialog.Callback {
         val activityModel = intent?.serializable<ActivityModel>(ARG_ACTIVITY_MODEL)
         val historyModel = intent?.serializable<HistoryModel>(ARG_HISTORY_MODEL)
 
-        binding.label.setText(activityModel?.name)
+        binding.label.addTextChangedListener(object : TextWatcher {
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
+            }
+
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+                binding.valueLayout.endIconMode =
+                    if (count != 0) TextInputLayout.END_ICON_CLEAR_TEXT
+                    else TextInputLayout.END_ICON_DROPDOWN_MENU
+            }
+
+            override fun afterTextChanged(s: Editable?) {
+            }
+        })
+        binding.label.setText(activityModel?.label)
         binding.label.text?.let { binding.label.setSelection(it.length) }
+        binding.label.setSimpleItems(arrayOf(activityModel?.label, activityModel?.name))
+
 
         val loader = IconPackLoader(applicationContext)
         iconPack = createMaterialDesignIconPack(loader)

--- a/app/src/main/res/layout/activity_add_shortcut.xml
+++ b/app/src/main/res/layout/activity_add_shortcut.xml
@@ -34,19 +34,18 @@
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/value_layout"
-        style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+        style="?textInputOutlinedExposedDropdownMenuStyle"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="10dp"
-        app:endIconMode="clear_text"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/icon">
 
-        <com.google.android.material.textfield.TextInputEditText
+        <com.google.android.material.textfield.MaterialAutoCompleteTextView
             android:id="@+id/label"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:hint="@string/shortcut_name"
             android:inputType="text" />
 


### PR DESCRIPTION
When creating shortcuts, people will also want to use the activity label rather than the activity name, especially for people who use non-English languages.

I've added a drop down selection box so that the user can select the event name directly after clearing the edit box.
![Screenshot_2023-08-21-03-49-09-649_com activitymanager dev](https://github.com/sdex/ActivityManager/assets/51242302/9ab2ed92-dfeb-4a93-ae3a-c8ce52b7919f)
![Screenshot_2023-08-21-03-49-03-596_com activitymanager dev](https://github.com/sdex/ActivityManager/assets/51242302/44be4f1b-d4b8-47ff-9af2-6a668e7f5a27)
