### PR TITLE
Change Google play to app market

### DIFF
--- a/app/src/main/assets/licenses.html
+++ b/app/src/main/assets/licenses.html
@@ -125,5 +125,33 @@ Unless required by applicable law or agreed to in writing, software distributed 
     OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 </pre>
 
+<ul>
+    <li>Pictogrammers (<a href="https://pictogrammers.com/" target="_blank">https://pictogrammers.com/</a>)
+    </li>
+</ul>
+<pre>
+    Pictogrammers Free License
+    --------------------------
+
+    Last Updated: February 1st, 2023
+
+    This package is released as free, open-source, and GPL friendly by
+    the [Pictogrammers](https://pictogrammers.com/). You may use it
+    for commercial projects, open-source projects, or anything really.
+
+    # Icons: Apache 2.0 (https://www.apache.org/licenses/LICENSE-2.0)
+    Some of the icons are redistributed under the Apache 2.0 license. All other
+    icons are either redistributed under their respective licenses or are
+    distributed under the Apache 2.0 license.
+
+    # Fonts: Apache 2.0 (https://www.apache.org/licenses/LICENSE-2.0)
+    All web and desktop fonts are distributed under the Apache 2.0 license. Web
+    and desktop fonts contain some icons that are redistributed under the Apache
+    2.0 license. All other icons are either redistributed under their respective
+    licenses or are distributed under the Apache 2.0 license.
+
+    # Code: MIT (https://opensource.org/licenses/MIT)
+    The MIT license applies to all non-font and non-icon files.
+</pre>
 </body>
 </html>

--- a/app/src/main/java/com/sdex/activityrunner/app/dialog/ApplicationOptionsDialog.kt
+++ b/app/src/main/java/com/sdex/activityrunner/app/dialog/ApplicationOptionsDialog.kt
@@ -88,8 +88,8 @@ class ApplicationOptionsDialog : BottomSheetDialogFragment() {
             IntentUtils.openApplicationInfo(requireActivity(), packageName)
             dismissAllowingStateLoss()
         }
-        binding.actionOpenAppPlayStore.setOnClickListener {
-            AppUtils.openPlayStore(context, packageName)
+        binding.actionOpenAppMarket.setOnClickListener {
+            AppUtils.openAppMarket(context, packageName)
             dismissAllowingStateLoss()
         }
     }

--- a/app/src/main/java/com/sdex/activityrunner/util/AppUtils.java
+++ b/app/src/main/java/com/sdex/activityrunner/util/AppUtils.java
@@ -47,14 +47,14 @@ public class AppUtils {
                 e.printStackTrace();
             }
         }
-        openPlayStore(context, appPackageName);
+        openAppMarket(context, appPackageName);
     }
 
-    public static void openPlayStore(Context context) {
-        openPlayStore(context, context.getPackageName());
+    public static void openAppMarket(Context context) {
+        openAppMarket(context, context.getPackageName());
     }
 
-    public static void openPlayStore(Context context, String appPackageName) {
+    public static void openAppMarket(Context context, String appPackageName) {
         try {
             context.startActivity(
                     new Intent(Intent.ACTION_VIEW, Uri.parse("market://details?id=" + appPackageName)));

--- a/app/src/main/res/drawable/ic_application_open_market.xml
+++ b/app/src/main/res/drawable/ic_application_open_market.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M19 6H17C17 3.2 14.8 1 12 1S7 3.2 7 6H5C3.9 6 3 6.9 3 8V20C3 21.1 3.9 22 5 22H19C20.1 22 21 21.1 21 20V8C21 6.9 20.1 6 19 6M12 3C13.7 3 15 4.3 15 6H9C9 4.3 10.3 3 12 3M19 20H5V8H19V20M12 12C10.3 12 9 10.7 9 9H7C7 11.8 9.2 14 12 14S17 11.8 17 9H15C15 10.7 13.7 12 12 12Z" />
+</vector>

--- a/app/src/main/res/drawable/ic_application_open_play.xml
+++ b/app/src/main/res/drawable/ic_application_open_play.xml
@@ -1,9 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-    <path
-        android:fillColor="#fff"
-        android:pathData="M6.1563,2C6.0195,1.9805 5.8789,1.9961 5.75,2.0313L15,11.2813L17.3125,9L6.5313,2.1563C6.4023,2.0742 6.293,2.0195 6.1563,2ZM5.0313,2.75C5.0078,2.832 5,2.9102 5,3L5,21C5,21.0898 5.0078,21.168 5.0313,21.25L14.2813,12ZM18.1563,9.5313L15.7188,12L18.1563,14.4688L20.6875,12.8438C21.2969,12.4492 21.2969,11.5508 20.6875,11.1563ZM15,12.7188L5.75,21.9688C6.0078,22.0391 6.2734,22.0078 6.5313,21.8438L17.3125,15Z" />
-</vector>

--- a/app/src/main/res/layout/dialog_application_menu.xml
+++ b/app/src/main/res/layout/dialog_application_menu.xml
@@ -136,19 +136,19 @@
         </LinearLayout>
 
         <LinearLayout
-            android:id="@+id/action_open_app_play_store"
+            android:id="@+id/action_open_app_market"
             style="@style/BottomDialogItemStyle">
 
             <ImageView
                 android:layout_width="50dp"
                 android:layout_height="50dp"
                 android:scaleType="center"
-                app:srcCompat="@drawable/ic_application_open_play"
+                app:srcCompat="@drawable/ic_application_open_market"
                 app:tint="@color/icon_tint" />
 
             <TextView
                 style="@style/BottomDialogTextStyle"
-                android:text="@string/application_option_action_launch" />
+                android:text="@string/application_option_open_market" />
 
         </LinearLayout>
 

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -10,7 +10,7 @@
     <string name="application_option_open">启动应用程序</string>
     <string name="application_option_open_manifest">打开清单查看器</string>
     <string name="application_option_open_info">打开应用信息</string>
-    <string name="application_option_action_launch">在 Google Play 中打开</string>
+    <string name="application_option_open_market">在应用市场中打开</string>
     <string name="application_disabled">已停用</string>
     <string name="application_system">系统</string>
     <!-- create shortcut -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,7 +10,7 @@
     <string name="application_option_open">Launch the application</string>
     <string name="application_option_open_manifest">Open manifest viewer</string>
     <string name="application_option_open_info">Open application info</string>
-    <string name="application_option_action_launch">Open in GooglePlay</string>
+    <string name="application_option_open_market">Open in app market</string>
     <string name="application_disabled">Disabled</string>
     <string name="application_system">System</string>
     <!-- create shortcut -->


### PR DESCRIPTION
This PR only modifies the names and icons without changing the underlying logic.

The icons are licensed under the [Pictogrammers Free License](https://pictogrammers.com/docs/general/about/). There is an older version of Material Design Icons in the project, which I think can be removed (but I haven't done so yet because I'm not sure if all icons in the project are using the latest version).