### PR TITLE
Improve shortcut icons and add icon color inversion

### DIFF
--- a/app/src/main/java/com/sdex/activityrunner/shortcut/AddShortcutDialogActivity.kt
+++ b/app/src/main/java/com/sdex/activityrunner/shortcut/AddShortcutDialogActivity.kt
@@ -96,6 +96,8 @@ class AddShortcutDialogActivity : AppCompatActivity(), IconDialog.Callback {
             binding.useRoot.isVisible = true
             binding.useRoot.isChecked = !activityModel.exported
 
+            binding.invertIconColors.isVisible = true
+
             binding.label.doOnTextChanged { _, _, _, count ->
                 binding.valueLayout.endIconMode = if (count == 0) {
                     TextInputLayout.END_ICON_DROPDOWN_MENU
@@ -139,7 +141,8 @@ class AddShortcutDialogActivity : AppCompatActivity(), IconDialog.Callback {
                     this,
                     model,
                     bitmap,
-                    binding.useRoot.isChecked
+                    binding.useRoot.isChecked,
+                    binding.invertIconColors.isChecked
                 )
             }
 

--- a/app/src/main/res/layout/activity_add_shortcut.xml
+++ b/app/src/main/res/layout/activity_add_shortcut.xml
@@ -62,6 +62,17 @@
         app:layout_constraintTop_toBottomOf="@id/value_layout"
         tools:visibility="visible" />
 
+    <CheckBox
+        android:id="@+id/invert_icon_colors"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:checked="false"
+        android:text="@string/shortcut_invert_icon_colors"
+        android:visibility="gone"
+        app:layout_constraintTop_toBottomOf="@id/use_root"
+        tools:visibility="visible" />
+
     <Button
         android:id="@+id/create"
         style="?buttonBarButtonStyle"
@@ -79,7 +90,7 @@
         android:layout_marginTop="8dp"
         android:text="@android:string/cancel"
         app:layout_constraintEnd_toStartOf="@+id/create"
-        app:layout_constraintTop_toBottomOf="@+id/use_root" />
+        app:layout_constraintTop_toBottomOf="@+id/invert_icon_colors" />
 
     <ImageView
         android:id="@+id/imageView"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,6 +21,7 @@
     <string name="icons_loading_error">Failed to load the icons</string>
     <string name="shortcut_icon_gallery">Pick from gallery</string>
     <string name="shortcut_icon_preset">Select from icons</string>
+    <string name="shortcut_invert_icon_colors">Invert icon colors</string>
     <!-- launching activity -->
     <string name="starting_activity">Starting activity: %s</string>
     <string name="starting_activity_failed">Failed to start activity: %s</string>


### PR DESCRIPTION
Android 16 QPR2 now adds monochrome theming to icons that don't support monochrome layer. This also applies to shortcuts, however their colors appear inversed when iconpack is used because white background and black glyph are used.
This PR adds an option to inverse colors to fix this issue.
<img width="455" height="130" alt="517f5a13-753e-4df0-876b-fccdbebd350a" src="https://github.com/user-attachments/assets/fa825191-315a-40c6-bfab-be60119cc556" />

This PR also improves non-themed icons by making them larger.
<img width="311" height="135" alt="1d65e47c-cee0-4a5b-8460-66072b83f38f" src="https://github.com/user-attachments/assets/2a1a6a27-2f74-4453-b299-e1329823c5a2" />
