### PR TITLE
Make dialog message selectable

### DIFF
--- a/app/src/main/java/com/sdex/activityrunner/util/IntentUtils.kt
+++ b/app/src/main/java/com/sdex/activityrunner/util/IntentUtils.kt
@@ -8,6 +8,7 @@ import android.content.Intent
 import android.graphics.Bitmap
 import android.graphics.drawable.Drawable
 import android.provider.Settings
+import android.widget.TextView
 import android.widget.Toast
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.core.graphics.drawable.toBitmap
@@ -158,7 +159,10 @@ object IntentUtils {
                 .setTitle(R.string.starting_activity_intent_failed)
                 .setMessage(e.message)
                 .setPositiveButton(android.R.string.ok, null)
-                .show()
+                .show().apply {
+                    val messageTextView = findViewById<TextView>(android.R.id.message)
+                    messageTextView?.setTextIsSelectable(true)
+                }
         }
     }
 

--- a/app/src/main/res/layout/dialog_export_intent_as_uri.xml
+++ b/app/src/main/res/layout/dialog_export_intent_as_uri.xml
@@ -10,6 +10,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:textAppearance="?attr/textAppearanceTitleMedium"
+        android:textIsSelectable="true"
         android:textSize="18sp"
         tools:text="intent:#Intent;action=com.app.open;end" />
 


### PR DESCRIPTION
Sometimes, people want to selectively copy text from dialog, and before they had to rely on system-level OCR features. However, these system-level tools not only start slowly but also have a chance of making errors. Now, PR makes it possible to copy some information from dialog boxes directly, so you can easily extract the content you need.

## Screenshots

![Screenshot_20260120_091353_com activitymanager dev](https://github.com/user-attachments/assets/45d2e0e2-31fc-478b-8053-3f7d38e1755f)
![Screenshot_20260120_091114_com activitymanager dev](https://github.com/user-attachments/assets/d1e8b8da-c292-48ff-85dc-a383f37f9eea)
