### PR TITLE
More columns on large screen for history

### DIFF
--- a/app/src/main/res/layout/activity_history.xml
+++ b/app/src/main/res/layout/activity_history.xml
@@ -28,7 +28,8 @@
             app:fastScrollThumbColor="?colorPrimary"
             app:fastScrollThumbInactiveColor="@color/scrollbar_inactive_thumb"
             app:fastScrollTrackColor="@color/scrollbar_background"
-            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
+            app:spanCount="@integer/list_history_span_count"
             tools:itemCount="15"
             tools:listitem="@layout/item_history"
             tools:visibility="visible" />

--- a/app/src/main/res/values-w1280dp/integers.xml
+++ b/app/src/main/res/values-w1280dp/integers.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="list_history_span_count">4</integer>
+</resources>

--- a/app/src/main/res/values-w640dp/integers.xml
+++ b/app/src/main/res/values-w640dp/integers.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="list_history_span_count">2</integer>
+</resources>

--- a/app/src/main/res/values-w960dp/integers.xml
+++ b/app/src/main/res/values-w960dp/integers.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="list_history_span_count">3</integer>
+</resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -46,15 +46,15 @@
     <!-- intent builder -->
     <string name="launch_param_package_name">包名</string>
     <string name="launch_param_class_name">类名</string>
-    <string name="launch_param_action">操作（Action）</string>
-    <string name="launch_param_data">数据（Data）</string>
+    <string name="launch_param_action">操作</string>
+    <string name="launch_param_data">数据</string>
     <string name="launch_param_mime_type">Mime 类型</string>
-    <string name="launch_param_extras">附加（Extras）</string>
+    <string name="launch_param_extras">附加</string>
     <string name="launch_param_extras_add">+ 添加选项</string>
-    <string name="launch_param_categories">类别（Categories）</string>
-    <string name="launch_param_flags">标志（Flags）</string>
+    <string name="launch_param_categories">类别</string>
+    <string name="launch_param_flags">标志</string>
     <string name="save_to_history">保存到历史记录</string>
-    <string name="item_history_has_extras">附加（Extras）</string>
+    <string name="item_history_has_extras">附加</string>
     <string name="item_history_has_categories">类别</string>
     <string name="item_history_has_flags">标志</string>
     <string name="about_donation">支持开发</string>

--- a/app/src/main/res/values/integers.xml
+++ b/app/src/main/res/values/integers.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- history -->
+    <integer name="list_history_span_count">1</integer>
+
+</resources>


### PR DESCRIPTION
The user experience of large screens is better now.

I’ve updated the Chinese text by removing the English parts, so it displays better in smaller cards.

## Screenshots

| English | Chinese
|-|-
|<img width="1126" height="947" alt="Snipaste_2026-01-20_10-10-17" src="https://github.com/user-attachments/assets/674433a8-af02-41a4-8138-657243ff46a9" />|<img width="1130" height="965" alt="Snipaste_2026-01-20_10-09-52" src="https://github.com/user-attachments/assets/407be78f-6a0b-434b-9cfe-7f6599c942cf" />

MatePad 11 real-device demo:

![Screenshot_20260120_102533_com activitymanager dev](https://github.com/user-attachments/assets/aec29aa1-c94d-4a00-8349-01c3fadd8ff6)
