### PR TITLE
Use developer.android.google.cn for CN

### DIFF
--- a/app/src/main/java/com/sdex/activityrunner/manifest/ManifestViewerActivity.kt
+++ b/app/src/main/java/com/sdex/activityrunner/manifest/ManifestViewerActivity.kt
@@ -151,7 +151,7 @@ class ManifestViewerActivity : BaseActivity() {
             }
 
             R.id.action_help -> {
-                val url = "https://developer.android.com/guide/topics/manifest/manifest-intro"
+                val url = getString(R.string.manifest_viewer_help_url)
                 IntentUtils.openBrowser(this, url)
                 true
             }

--- a/app/src/main/res/values-mcc460/urls.xml
+++ b/app/src/main/res/values-mcc460/urls.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="manifest_viewer_help_url" translatable="false">https://developer.android.google.cn/guide/topics/manifest/manifest-intro</string>
+</resources>

--- a/app/src/main/res/values/urls.xml
+++ b/app/src/main/res/values/urls.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="manifest_viewer_help_url" translatable="false">https://developer.android.com/guide/topics/manifest/manifest-intro</string>
+</resources>


### PR DESCRIPTION
Make slight adjustments to provide region-specific links for areas that cannot access [developer.android.com](https://developer.android.com/).

| Region | Domain | whois lookup |
|-|-|-
| China | `developer.android.google.cn` | [www.whois.com](https://www.whois.com/whois/google.cn) |

`developer.android.google.cn` may only be accessible within mainland China, and users outside mainland China may be unable to access this link.

The difference between `developer.android.google.cn` and `developer.android.com` is solely that `developer.android.google.cn` uses WeChat login and some resources are unavailable.

<img width="1999" height="1466" alt="image" src="https://github.com/user-attachments/assets/000bf043-32a7-458d-932d-7d060977152b" />

<img width="1999" height="1466" alt="image" src="https://github.com/user-attachments/assets/e854eacc-1b87-4bc7-a4e5-95df0bbbe586" />


>[!NOTE]
>
> `mcc460` is a Mobile Country Codes for China. More codes can be found at https://www.mcc-mnc.com/.